### PR TITLE
Fixes dependencies for new obsidian api on npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# npm
+node_modules
+
+# build
+main.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@rollup/plugin-node-resolve": "^9.0.0",
         "@rollup/plugin-typescript": "^6.0.0",
         "@types/node": "^14.14.2",
-        "obsidian": "https://github.com/obsidianmd/obsidian-api/tarball/master",
+        "obsidian": "^0.12.2",
         "rollup": "^2.32.1",
         "tslib": "^2.0.3",
         "typescript": "^4.0.3"
@@ -87,9 +87,9 @@
       "dev": true
     },
     "node_modules/@types/codemirror": {
-      "version": "0.0.98",
-      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-0.0.98.tgz",
-      "integrity": "sha512-cbty5LPayy2vNSeuUdjNA9tggG+go5vAxmnLDRWpiZI5a+RDBi9dlozy4/jW/7P/gletbBWbQREEa7A81YxstA==",
+      "version": "0.0.108",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-0.0.108.tgz",
+      "integrity": "sha512-3FGFcus0P7C2UOGCNUVENqObEb4SFk+S8Dnxq7K6aIsLVs/vDtlangl3PEO0ykaKXyK56swVF6Nho7VsA44uhw==",
       "dev": true,
       "dependencies": {
         "@types/tern": "*"
@@ -292,12 +292,23 @@
         "node": "*"
       }
     },
+    "node_modules/moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/obsidian": {
-      "resolved": "https://github.com/obsidianmd/obsidian-api/tarball/master",
-      "integrity": "sha512-OGZPxkzYJ1Lgjd4f7eaBFr8KqIG8vkwVcOblH5BMSIoMieY1NmXL9/ouVwMjc1NJH7ZN6Zi7Qclz8Y42fd8rwQ==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-0.12.2.tgz",
+      "integrity": "sha512-lvrJ6GEUkKrHCpbSDO6NdGdkSYQ/0ElGYizdcw4mRlMiHTOFgYjbqv+fEMkyLIneF0uB7epf9YNQEyFtRF2ESA==",
       "dev": true,
       "dependencies": {
-        "@types/codemirror": "0.0.98"
+        "@types/codemirror": "0.0.108",
+        "moment": "2.29.1"
       }
     },
     "node_modules/once": {
@@ -450,9 +461,9 @@
       }
     },
     "@types/codemirror": {
-      "version": "0.0.98",
-      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-0.0.98.tgz",
-      "integrity": "sha512-cbty5LPayy2vNSeuUdjNA9tggG+go5vAxmnLDRWpiZI5a+RDBi9dlozy4/jW/7P/gletbBWbQREEa7A81YxstA==",
+      "version": "0.0.108",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-0.0.108.tgz",
+      "integrity": "sha512-3FGFcus0P7C2UOGCNUVENqObEb4SFk+S8Dnxq7K6aIsLVs/vDtlangl3PEO0ykaKXyK56swVF6Nho7VsA44uhw==",
       "dev": true,
       "requires": {
         "@types/tern": "*"
@@ -634,12 +645,20 @@
         "brace-expansion": "^1.1.7"
       }
     },
+    "moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "dev": true
+    },
     "obsidian": {
-      "version": "https://github.com/obsidianmd/obsidian-api/tarball/master",
-      "integrity": "sha512-OGZPxkzYJ1Lgjd4f7eaBFr8KqIG8vkwVcOblH5BMSIoMieY1NmXL9/ouVwMjc1NJH7ZN6Zi7Qclz8Y42fd8rwQ==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-0.12.2.tgz",
+      "integrity": "sha512-lvrJ6GEUkKrHCpbSDO6NdGdkSYQ/0ElGYizdcw4mRlMiHTOFgYjbqv+fEMkyLIneF0uB7epf9YNQEyFtRF2ESA==",
       "dev": true,
       "requires": {
-        "@types/codemirror": "0.0.98"
+        "@types/codemirror": "0.0.108",
+        "moment": "2.29.1"
       }
     },
     "once": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@rollup/plugin-node-resolve": "^9.0.0",
     "@rollup/plugin-typescript": "^6.0.0",
     "@types/node": "^14.14.2",
-    "obsidian": "https://github.com/obsidianmd/obsidian-api/tarball/master",
+    "obsidian": "^0.12.2",
     "rollup": "^2.32.1",
     "tslib": "^2.0.3",
     "typescript": "^4.0.3"


### PR DESCRIPTION
Fixed dependencies in `package.json` which was causing an error when building with `npm i` due to the obsidian api moving to [npm](https://www.npmjs.com/package/obsidian).
Also added a gitignore file to untrack build files.