### PR TITLE
Enabled snippet expansion in math environments

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -103,10 +103,11 @@ export default class TextSnippets extends Plugin {
 		var nlSymb = this.settings.newlineSymbol;
 		var stopSymbol = this.settings.stopSymbol;
 		var stopFound = false;
+        var ignored = ['$', '{', '}', '[', ']', '(', ')']
 
 		var selectedWoSpaces = selectedText.split(' ').join('');
 
-		if (selectedWoSpaces == '' || selectedWoSpaces == '$' && cursorOrig.ch == cursor.ch) {
+		if (selectedWoSpaces == '' || ignored.indexOf(selectedWoSpaces[0]) >= 0 && cursorOrig.ch == cursor.ch) {
 			editor.execCommand('goWordLeft');
 			editor.execCommand('goWordLeft');
 			selectedText = this.getSelectedText(editor);

--- a/main.ts
+++ b/main.ts
@@ -106,7 +106,7 @@ export default class TextSnippets extends Plugin {
 
 		var selectedWoSpaces = selectedText.split(' ').join('');
 
-		if (selectedWoSpaces == '' && cursorOrig.ch == cursor.ch) {
+		if (selectedWoSpaces == '' || selectedWoSpaces == '$' && cursorOrig.ch == cursor.ch) {
 			editor.execCommand('goWordLeft');
 			editor.execCommand('goWordLeft');
 			selectedText = this.getSelectedText(editor);


### PR DESCRIPTION
Fixes #9 by disregarding the latex math environment delimiter `$` instead of treating it as a word, which would stop the plugin from searching for the correct word to expand. @y9san9