### PR TITLE
fix main.js

### DIFF
--- a/main.js
+++ b/main.js
@@ -96,13 +96,14 @@ class TextSnippets extends obsidian.Plugin {
     }
     getWordBoundaries(editor) {
         var cursor = editor.getCursor();
+        var ch = cursor.ch;
         var line = cursor.line;
-        var word = editor.findWordAt({
+        var word = editor.wordAt({
             line: line,
-            ch: cursor.ch
+            ch: cursor
         });
-        var wordStart = word.anchor.ch;
-        var wordEnd = word.head.ch;
+        var wordStart = word.from.ch;
+        var wordEnd = word.to.ch;
         return {
             start: {
                 line: line,


### PR DESCRIPTION
Fixed plugin for obsidian 0.13.23 changed editor.findWordAt method to editor.wordAt and changed properties accordingly.